### PR TITLE
Set match-client-id to false in README.md example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Example Playbook
                        data: 8.8.8.8, 8.8.4.4
                      - name: routers
                        data: 192.0.2.254
+                   match-client-id: false
                    reservations:
                      - hostname: static-host.example.org
                        hw-address: aa:bb:cc:dd:ee:ff


### PR DESCRIPTION
Matching on client-id doesn't work well went setting DHCP reservations for hosts which are PXE booted:

https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html#using-client-identifier-and-hardware-address