### PR TITLE
Kea version 2.4 + minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# editors
+*.code-workspace
+*.swp
+*~
+
+# secrets
+*.key

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Installation
 
 This role can either be installed manually with the ansible-galaxy CLI tool:
 
-    ansible-galaxy install git+https://github.com/jarppiko/ansible-role-kea,main
+    ansible-galaxy install git+https://github.com/wandansible/ansible-role-kea,main
      
 Or, by adding the following to `requirements.yml`:
 
-    - name: jarppiko.kea
-      src: https://github.com/jarppiko/ansible-role-kea
+    - name: wandansible.kea
+      src: https://github.com/wandansible/ansible-role-kea
 
 Roles listed in `requirements.yml` can be installed with the following ansible-galaxy command:
 
@@ -108,7 +108,7 @@ Example Playbook
 
     - hosts: dhcp_servers
       roles:
-         - role: jarppiko.kea
+         - role: wandansible.kea
            become: true
            vars:
              kea_dhcp4_config:

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Installation
 
 This role can either be installed manually with the ansible-galaxy CLI tool:
 
-    ansible-galaxy install git+https://github.com/jarppiko/ansible-kea,main
+    ansible-galaxy install git+https://github.com/jarppiko/ansible-role-kea,main
      
 Or, by adding the following to `requirements.yml`:
 
     - name: jarppiko.kea
-      src: https://github.com/jarppiko/ansible-kea
+      src: https://github.com/jarppiko/ansible-role-kea
 
 Roles listed in `requirements.yml` can be installed with the following ansible-galaxy command:
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Installation
 
 This role can either be installed manually with the ansible-galaxy CLI tool:
 
-    ansible-galaxy install git+https://github.com/wandansible/kea,main,wandansible.kea
+    ansible-galaxy install git+https://github.com/jarppiko/ansible-kea,main
      
 Or, by adding the following to `requirements.yml`:
 
-    - name: wandansible.kea
-      src: https://github.com/wandansible/kea
+    - name: jarppiko.kea
+      src: https://github.com/jarppiko/ansible-kea
 
 Roles listed in `requirements.yml` can be installed with the following ansible-galaxy command:
 
@@ -108,7 +108,7 @@ Example Playbook
 
     - hosts: dhcp_servers
       roles:
-         - role: wandansible.kea
+         - role: jarppiko.kea
            become: true
            vars:
              kea_dhcp4_config:

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ Installation
 
 This role can either be installed manually with the ansible-galaxy CLI tool:
 
-    ansible-galaxy install git+https://github.com/wandansible/ansible-role-kea,main
+    ansible-galaxy install git+https://github.com/wandansible/kea,main,wandansible.kea
      
 Or, by adding the following to `requirements.yml`:
 
     - name: wandansible.kea
-      src: https://github.com/wandansible/ansible-role-kea
+      src: https://github.com/wandansible/kea
 
 Roles listed in `requirements.yml` can be installed with the following ansible-galaxy command:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,18 +1,19 @@
 ---
-kea_apt_repo_version: 2-3
-kea_apt_key_fingerprint: 95B6C7ABDAEE9F164891B962DA05D46B7BABA24A
+kea_apt_repo_version: 2-4
+kea_apt_key_fingerprint: 4AD10B6C98E09742E530EC4F0D9D9A1439E23DB9
 kea_packages:
   - isc-kea-admin
   - isc-kea-hooks
+  - isc-kea-ctrl-agent
 
 kea_dhcp4_package: >-
-  {{ 'isc-kea-dhcp4' if kea_apt_repo_version is version('2-3', '>=')
+  {{ 'isc-kea-dhcp4' if ansible_facts[‘distribution’] is 'Alpine'
   else 'isc-kea-dhcp4-server' }}
 kea_dhcp6_package: >-
-  {{ 'isc-kea-dhcp6' if kea_apt_repo_version is version('2-3', '>=')
+  {{ 'isc-kea-dhcp6' if ansible_facts[‘distribution’] is 'Alpine'
   else 'isc-kea-dhcp6-server' }}
 kea_ddns_package: >-
-  {{ 'isc-kea-dhcp-ddns' if kea_apt_repo_version is version('2-3', '>=')
+  {{ 'isc-kea-dhcp-ddns' if ansible_facts[‘distribution’] is 'Alpine'
   else 'isc-kea-dhcp-ddns-server' }}
 kea_control_agent_package: isc-kea-ctrl-agent
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,11 +5,11 @@ kea_packages:
   - isc-kea-admin
   - isc-kea-hooks
 
-# which Kea components to enable 
+# which Kea components to enable
 kea_dhcp4_enabled: true
 kea_dhcp6_enabled: false
 kea_ddns_enabled: false
-kea_control_agent_enabled: true
+kea_control_agent_enabled: false
 
 kea_dhcp4_package: >-
   {{ 'isc-kea-dhcp4' if ansible_facts[‘distribution’] is 'Alpine'
@@ -21,7 +21,6 @@ kea_ddns_package: >-
   {{ 'isc-kea-dhcp-ddns' if ansible_facts[‘distribution’] is 'Alpine'
   else 'isc-kea-dhcp-ddns-server' }}
 kea_control_agent_package: isc-kea-ctrl-agent
-
 kea_dhcp4_config: {}
 kea_dhcp6_config: {}
 kea_ddns_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,7 +18,7 @@ kea_dhcp6_package: >-
   {{ 'isc-kea-dhcp6' if ansible_facts['distribution'] == 'Alpine'
   else 'isc-kea-dhcp6-server' }}
 kea_ddns_package: >-
-  {{ 'isc-kea-dhcp-ddns' if ansible_facts['distribution'] == 'Alpine'
+  {{ 'isc-kea-dhcp-ddns' if kea_apt_repo_version is version('2-3', '>=')
   else 'isc-kea-dhcp-ddns-server' }}
 kea_control_agent_package: isc-kea-ctrl-agent
 kea_dhcp4_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,6 @@ kea_apt_key_fingerprint: 4AD10B6C98E09742E530EC4F0D9D9A1439E23DB9
 kea_packages:
   - isc-kea-admin
   - isc-kea-hooks
-  - isc-kea-ctrl-agent
 
 # which Kea components to enable 
 kea_dhcp4_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,13 +12,13 @@ kea_ddns_enabled: false
 kea_control_agent_enabled: false
 
 kea_dhcp4_package: >-
-  {{ 'isc-kea-dhcp4' if ansible_facts[‘distribution’] is 'Alpine'
+  {{ 'isc-kea-dhcp4' if ansible_facts['distribution'] is 'Alpine'
   else 'isc-kea-dhcp4-server' }}
 kea_dhcp6_package: >-
-  {{ 'isc-kea-dhcp6' if ansible_facts[‘distribution’] is 'Alpine'
+  {{ 'isc-kea-dhcp6' if ansible_facts['distribution'] is 'Alpine'
   else 'isc-kea-dhcp6-server' }}
 kea_ddns_package: >-
-  {{ 'isc-kea-dhcp-ddns' if ansible_facts[‘distribution’] is 'Alpine'
+  {{ 'isc-kea-dhcp-ddns' if ansible_facts['distribution'] is 'Alpine'
   else 'isc-kea-dhcp-ddns-server' }}
 kea_control_agent_package: isc-kea-ctrl-agent
 kea_dhcp4_config: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,12 @@ kea_packages:
   - isc-kea-hooks
   - isc-kea-ctrl-agent
 
+# which Kea components to enable 
+kea_dhcp4_enabled: true
+kea_dhcp6_enabled: false
+kea_ddns_enabled: false
+kea_control_agent_enabled: true
+
 kea_dhcp4_package: >-
   {{ 'isc-kea-dhcp4' if ansible_facts[‘distribution’] is 'Alpine'
   else 'isc-kea-dhcp4-server' }}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,13 +12,13 @@ kea_ddns_enabled: false
 kea_control_agent_enabled: false
 
 kea_dhcp4_package: >-
-  {{ 'isc-kea-dhcp4' if ansible_facts['distribution'] is 'Alpine'
+  {{ 'isc-kea-dhcp4' if ansible_facts['distribution'] == 'Alpine'
   else 'isc-kea-dhcp4-server' }}
 kea_dhcp6_package: >-
-  {{ 'isc-kea-dhcp6' if ansible_facts['distribution'] is 'Alpine'
+  {{ 'isc-kea-dhcp6' if ansible_facts['distribution'] == 'Alpine'
   else 'isc-kea-dhcp6-server' }}
 kea_ddns_package: >-
-  {{ 'isc-kea-dhcp-ddns' if ansible_facts['distribution'] is 'Alpine'
+  {{ 'isc-kea-dhcp-ddns' if ansible_facts['distribution'] == 'Alpine'
   else 'isc-kea-dhcp-ddns-server' }}
 kea_control_agent_package: isc-kea-ctrl-agent
 kea_dhcp4_config: {}

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -8,7 +8,7 @@ argument_specs:
           Repository version to track,
           for available versions see: https://cloudsmith.io/~isc/repos/
         type: str
-        default: 2-3
+        default: 2-4
 
       kea_apt_key_fingerprint:
         description: Fingerprint for kea apt key
@@ -28,7 +28,7 @@ argument_specs:
           defaults to "isc-kea-dhcp4-server"
           if the kea version is less than 2.3
         type: str
-        default: isc-kea-dhcp4
+        default: isc-kea-dhcp4-server
 
       kea_dhcp6_package:
         description: |
@@ -36,7 +36,7 @@ argument_specs:
           defaults to "isc-kea-dhcp6-server"
           if the kea version is less than 2.3
         type: str
-        default: isc-kea-dhcp6
+        default: isc-kea-dhcp6-server
 
       kea_ddns_package:
         description: |

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -20,6 +20,7 @@ galaxy_info:
         - focal
         - jammy
         - mantic
+        - noble
 
   galaxy_tags: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  namespace: wandansible
+  namespace: jarppiko
   role_name: kea
-  author: WAND Network Research Group
+  author: Github.com/jarppiko, adopted from github.com/wandansible/kea
   description: Install and configure Kea DHCP
 
   license: Apache-2.0
@@ -14,9 +14,11 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        - bookworm
     - name: Ubuntu
       versions:
-        - focal
+        - jammy
+        - mantic
 
   galaxy_tags: []
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  namespace: jarppiko
+  namespace: wandansible
   role_name: kea
-  author: Github.com/jarppiko, adopted from github.com/wandansible/kea
+  author: WAND Network Research Group
   description: Install and configure Kea DHCP
 
   license: Apache-2.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
         - bookworm
     - name: Ubuntu
       versions:
+        - focal
         - jammy
         - mantic
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,18 @@
 ---
 - ansible.builtin.import_tasks: apt.yml
 - ansible.builtin.import_tasks: dhcp4.yml
-  when: kea_dhcp4_config != {}
+  when: 
+    - kea_dhcp4_enabled
+    - kea_dhcp4_config != {}
 - ansible.builtin.import_tasks: dhcp6.yml
-  when: kea_dhcp6_config != {}
+  when: 
+    - kea_dhcp6_enabled
+    - kea_dhcp6_config != {}
 - ansible.builtin.import_tasks: ddns.yml
-  when: kea_ddns_config != {}
+  when: 
+    - kea_ddns_enabled    
+    - kea_ddns_config != {}
 - ansible.builtin.import_tasks: ctrl-agent.yml
-  when: kea_control_agent_config != {}
+  when: 
+    - kea_control_agent_enabled
+    - kea_control_agent_config != {}


### PR DESCRIPTION
Thank you for a great Ansible role. I am contributing version update and minor fixes/config variables to upstream. 

- Kea version 2.4 (latest stable version)
- Fix Kea package naming as defined in https://kb.isc.org/docs/upgrading-packages-beyond-kea-232
- add component enabled/disabled variables: 
  - `kea_dhcp4_enabled` 
  - `kea_dhcp6_enabled`
  - `kea_ddns_enabled`
  - `kea_control_agent_enabled`

_PS. Apologies for ugly commit history. I am pretty new to Ansible. There are not that many line changes._ 